### PR TITLE
Create group dynamically 

### DIFF
--- a/awa-chat-flutter/awachat/lib/main.dart
+++ b/awa-chat-flutter/awachat/lib/main.dart
@@ -428,13 +428,21 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
               IconButton(
                   tooltip: "Changer de groupe",
                   onPressed: () {
+                    if (state != "chat") {
+                      return;
+                    }
                     _webSocketConnection.switchgroup();
                     setState(() {
                       _messages.clear();
                       state = "switch";
                     });
                   },
-                  icon: const Icon(Icons.door_front_door_outlined)),
+                  icon: Icon(
+                    Icons.door_front_door_outlined,
+                    color: state == "chat"
+                        ? const Color(0xff6f61e8)
+                        : const Color(0xff9e9cab),
+                  )),
             ]),
         body: SafeArea(
             bottom: false,

--- a/sam-groups/actionbanrequest/app.js
+++ b/sam-groups/actionbanrequest/app.js
@@ -31,7 +31,6 @@ const {
   SEND_NOTIFICATION_TOPIC_ARN,
   AWS_REGION
 } = process.env
-
 const CONFIRMATION_REQUIRED = parseInt(CONFIRMATION_REQUIRED_STRING)
 
 const dynamoDBClient = new DynamoDBClient({ region: AWS_REGION })

--- a/sam-groups/samconfig.toml
+++ b/sam-groups/samconfig.toml
@@ -20,5 +20,5 @@ s3_prefix = "sam-group-development"
 region = "eu-west-3"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "UsersTableName=\"users_development\" GroupsTableName=\"groups_development\" ConfirmationRequired=\"2\" LogRetentionInDays=\"1\" StageName=\"dev\""
+parameter_overrides = "MinimumGroupSize=\"3\" MaximumGroupSize=\"5\" ConfirmationRequired=\"2\" UsersTableName=\"users_development\" GroupsTableName=\"groups_development\" LogRetentionInDays=\"1\" StageName=\"dev\""
 image_repositories = []

--- a/sam-groups/switchgroup/app.js
+++ b/sam-groups/switchgroup/app.js
@@ -1,3 +1,12 @@
+// NOTE
+// It is better to not have MINIMUM_GROUP_SIZE too small.
+// Indeed, on concurents return, one can update an old group
+// while the other delete it
+// keeping the group in the database forever for nothing
+// If MINIMUM_GROUP_SIZE is big enough (let say 3), the time window between
+// the deactivation of the group (isWaiting = 0) and its deletion should be
+// big enough to not have concurrent run trying to update and delete at the same time
+
 // DEPENDENCIES
 // aws-sdk-ddb
 // aws-sdk-sns
@@ -10,24 +19,37 @@
 // Switch group
 // event.Records[0].Sns.Message
 // id : String - user id
-// groupid : String? - user group id
-// connectionId : String? - user connection id
+// [unused] connectionId : String? - user connection id
 
 // ===== ==== ====
 // IMPORTS
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
-const { DynamoDBDocumentClient, UpdateCommand } = require('@aws-sdk/lib-dynamodb')
+const {
+  DynamoDBDocumentClient,
+  BatchGetCommand,
+  DeleteCommand,
+  GetCommand,
+  UpdateCommand,
+  ScanCommand
+} = require('@aws-sdk/lib-dynamodb')
 
 const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns')
+
+const { v4: uuidv4 } = require('uuid')
 
 // ===== ==== ====
 // CONSTANTS
 const {
+  MINIMUM_GROUP_SIZE_STRING,
+  MAXIMUM_GROUP_SIZE_STRING,
   USERS_TABLE_NAME,
   GROUPS_TABLE_NAME,
   SEND_MESSAGE_TOPIC_ARN,
+  // SEND_NOTIFICATION_TOPIC_ARN,
   AWS_REGION
 } = process.env
+const MINIMUM_GROUP_SIZE = parseInt(MINIMUM_GROUP_SIZE_STRING)
+const MAXIMUM_GROUP_SIZE = parseInt(MAXIMUM_GROUP_SIZE_STRING)
 
 const dynamoDBClient = new DynamoDBClient({ region: AWS_REGION })
 const dynamoDBDocumentClient = DynamoDBDocumentClient.from(dynamoDBClient)
@@ -49,21 +71,66 @@ ${event.Records[0].Sns.Message}
   const body = JSON.parse(event.Records[0].Sns.Message)
 
   const id = body.id
-  const groupid = body.groupid
-  // const connectionId = body.connectionId
 
   if (id === undefined) {
     throw new Error('id must be defined')
   }
 
-  // find a new group
-  let newgroupid = Math.floor(Math.random() * 9).toString()
-  if (newgroupid === groupid) {
-    newgroupid = (parseInt(newgroupid) + 1).toString()
+  // get user
+  const getUserCommand = new GetCommand({
+    TableName: USERS_TABLE_NAME,
+    Key: { id: id },
+    ProjectionExpression: '#id, #group, #connectionId',
+    ExpressionAttributeNames: {
+      '#id': 'id',
+      '#group': 'group',
+      '#connectionId': 'connectionId'
+    }
+  })
+  const user = await dynamoDBDocumentClient.send(getUserCommand).then((response) => (response.Item))
+  console.log('user:', user)
+
+  if (user === undefined) {
+    console.log(`user <${id}> doesn't exist`)
+    return {
+      statusCode: 204
+    }
   }
 
+  // query a new group (query doesn't work without a KeyConditionExpression, use scan instead)
+  // TODO: use a sort index to query only the waiting ones faster
+  const queryCommand = new ScanCommand({
+    TableName: GROUPS_TABLE_NAME,
+    ProjectionExpression: '#id, #users, #isWaiting',
+    FilterExpression: '#isWaiting = :true',
+    ExpressionAttributeNames: {
+      '#id': 'id',
+      '#users': 'users',
+      '#isWaiting': 'isWaiting'
+    },
+    ExpressionAttributeValues: {
+      ':true': 1
+    }
+  })
+  const newGroup = await dynamoDBDocumentClient.send(queryCommand).then((response) => {
+    if (response.Count > 0) {
+      for (const group of response.Items) {
+        if (group.id !== user.group) {
+          return group
+        }
+      }
+    }
+    return {
+      id: uuidv4(),
+      isWaiting: 1, // true
+      users: new Set()
+    }
+  })
+  newGroup.users.add(id) // simulate add user id (will be added -for real- below)
+  console.log(`put user <${id}> in group <${newGroup.id}>`)
+
+  // update user
   const updateUserCommand = new UpdateCommand({
-    ReturnValues: 'ALL_OLD',
     TableName: USERS_TABLE_NAME,
     Key: { id: id },
     UpdateExpression: `
@@ -78,53 +145,135 @@ ${event.Records[0].Sns.Message}
       '#confirmationRequired': 'confirmationRequired'
     },
     ExpressionAttributeValues: {
-      ':groupid': newgroupid
+      ':groupid': newGroup.id
     }
   })
-  const user = await dynamoDBDocumentClient.send(updateUserCommand).then((response) => (response.Attributes))
+  const promises = [dynamoDBDocumentClient.send(updateUserCommand).then((response) => (response.Attributes))]
+
+  // update new group
+  if (newGroup.users.size >= MINIMUM_GROUP_SIZE) {
+    // alert user(s)
+    const users = [{ id, connectionId: user.connectionId }]
+    if (newGroup.users.size === MINIMUM_GROUP_SIZE && MINIMUM_GROUP_SIZE > 1) {
+      // happens only once when group becomes active for the first time
+      newGroup.users.delete(id) // remove id, already fetched
+      const batchGetOtherUsers = new BatchGetCommand({
+        RequestItems: {
+          [USERS_TABLE_NAME]: {
+            Keys: Array.from(newGroup.users).map((id) => ({ id: id })),
+            ProjectionExpression: '#id, #connectionId',
+            ExpressionAttributeNames: {
+              '#id': 'id',
+              '#connectionId': 'connectionId'
+            }
+          }
+        }
+      })
+      newGroup.users.add(id)
+
+      const otherUsers = await dynamoDBDocumentClient.send(batchGetOtherUsers).then((response) => (response.Responses[USERS_TABLE_NAME]))
+      for (const otherUser of otherUsers) {
+        users.push(otherUser)
+      }
+    }
+    console.log(`Alert early group users <${newGroup.id}>:`, users)
+    const publishSendMessageCommand = new PublishCommand({
+      TopicArn: SEND_MESSAGE_TOPIC_ARN,
+      Message: JSON.stringify({
+        users: users,
+        message: {
+          action: 'switchgroup',
+          groupid: newGroup.id
+        }
+      })
+    })
+
+    promises.push(snsClient.send(publishSendMessageCommand))
+  }
+  if (newGroup.users.size >= MAXIMUM_GROUP_SIZE) {
+    newGroup.isWaiting = 0 // false
+  }
 
   const updateNewGroupCommand = new UpdateCommand({
     TableName: GROUPS_TABLE_NAME,
-    Key: { id: newgroupid },
-    UpdateExpression: 'ADD #users :id',
+    Key: { id: newGroup.id },
+    UpdateExpression: `
+    SET #isWaiting = :isWaiting
+    ADD #users :id
+    `,
     ExpressionAttributeNames: {
+      '#isWaiting': 'isWaiting',
       '#users': 'users'
     },
     ExpressionAttributeValues: {
-      ':id': new Set([id])
+      ':id': new Set([id]),
+      ':isWaiting': newGroup.isWaiting
     }
   })
+  promises.push(dynamoDBDocumentClient.send(updateNewGroupCommand))
 
-  const publishSendMessageCommand = new PublishCommand({
-    TopicArn: SEND_MESSAGE_TOPIC_ARN,
-    Message: JSON.stringify({
-      users: [{ id, connectionId: user.connectionId }],
-      message: {
-        action: 'switchgroup',
-        groupid: newgroupid
-      }
-    })
-  })
-
-  const promises = [
-    dynamoDBDocumentClient.send(updateUserCommand),
-    dynamoDBDocumentClient.send(updateNewGroupCommand),
-    snsClient.send(publishSendMessageCommand)
-  ]
-
+  // update old group (if any)
   if (user.group !== undefined) {
-    const updateOldGroupCommand = new UpdateCommand({
+    // get old group (need to count its users)
+    const getOldGroupCommand = new GetCommand({
       TableName: GROUPS_TABLE_NAME,
       Key: { id: user.group },
-      UpdateExpression: 'DELETE #users :id',
+      ProjectionExpression: '#id, #users, #isWaiting',
       ExpressionAttributeNames: {
-        '#users': 'users'
-      },
-      ExpressionAttributeValues: {
-        ':id': new Set([id])
+        '#id': 'id',
+        '#users': 'users',
+        '#isWaiting': 'isWaiting'
       }
     })
-    promises.push(dynamoDBDocumentClient.send(updateOldGroupCommand))
+    const oldGroup = await dynamoDBDocumentClient.send(getOldGroupCommand).then((response) => (response.Item))
+
+    // check oldGroup still exists (if concurrent runs)
+    if (oldGroup !== undefined) {
+      oldGroup.users = oldGroup.users ?? new Set()
+      oldGroup.users.delete(id) // simulate remove user id (will be removed -for real- below)
+
+      // NOTE: don't use if/else because both can be triggered (isWaiting to 0 will prevail)
+      if (oldGroup.users.size < MAXIMUM_GROUP_SIZE) {
+        oldGroup.isWaiting = 1 // true
+      }
+      if (oldGroup.users.size < MINIMUM_GROUP_SIZE) {
+        // NOTE: if an user leave a group it hasn't entered yet it will close it forever
+        // for exemple, user A join group ABC, group.users = { A }, group.isWaiting = 1
+        // user B join group ABD, group.users = { A, B }, group.isWaiting = 1
+        // user A switches group, group.users = { B } group.size < MINIMUM_GROUP_SIZE(3), group.isWaiting = 0
+        // group ABC will be closed before ever being opened
+        // TODO: cannot switch while waiting (cannot double-click on switch button)
+        oldGroup.isWaiting = 0 // false
+      }
+      if (oldGroup.users.size > 0) {
+        // update group
+        const updateOldGroupCommand = new UpdateCommand({
+          TableName: GROUPS_TABLE_NAME,
+          Key: { id: user.group },
+          UpdateExpression: `
+          SET #isWaiting = :isWaiting
+          DELETE #users :id
+          `,
+          ExpressionAttributeNames: {
+            '#isWaiting': 'isWaiting',
+            '#users': 'users'
+          },
+          ExpressionAttributeValues: {
+            ':id': new Set([id]),
+            ':isWaiting': oldGroup.isWaiting ?? 1 // isWaiting or true
+          }
+        })
+        promises.push(dynamoDBDocumentClient.send(updateOldGroupCommand))
+      } else {
+        // delete group
+        const deleteOldGroupCommand = new DeleteCommand({
+          TableName: GROUPS_TABLE_NAME,
+          Key: { id: user.group }
+        })
+        promises.push(dynamoDBDocumentClient.send(deleteOldGroupCommand))
+        console.log(`Delete old group <${user.group}>`)
+      }
+    }
   }
 
   await Promise.allSettled(promises)

--- a/sam-groups/switchgroup/package-lock.json
+++ b/sam-groups/switchgroup/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "switchgroup",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "switchgroup",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/sam-groups/switchgroup/package.json
+++ b/sam-groups/switchgroup/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "AdrKacz",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "uuid": "^8.3.2"
+  }
 }

--- a/sam-groups/template.yaml
+++ b/sam-groups/template.yaml
@@ -16,6 +16,21 @@ Description: >
   Manage users and their conversation in groups
 
 Parameters:
+  MinimumGroupSize:
+    Type: Number
+    Default: 3
+    Description: '(Required) The minimum number of users on a group to be opened.'
+    ConstraintDescription: 'Required. Must be an integer.'
+  MaximumGroupSize:
+    Type: Number
+    Default: 5
+    Description: '(Required) The maximum number of users on a group'
+    ConstraintDescription: 'Required. Must be an integer.'
+  ConfirmationRequired:
+    Type: Number
+    Default: 2
+    Description: '(Required) The number of the users required to ban someone from a group. The effective number of confirmation required will be the minimum between this number and the number of users who have received the ban request.'
+    ConstraintDescription: 'Required. Must be an integer.'
   UsersTableName:
     Type: String
     Default: 'users'
@@ -32,11 +47,6 @@ Parameters:
     MaxLength: 50
     AllowedPattern: ^[A-Za-z_]+$
     ConstraintDescription: 'Required. Can be characters and underscore only. No numbers or special characters allowed.'
-  ConfirmationRequired:
-    Type: Number
-    Default: 2
-    Description: '(Required) The number of the users required to ban someone from a group. The effective number of confirmation required will be the minimum between this number and the number of users who have received the ban request.'
-    ConstraintDescription: 'Required. Must be an integer.'
   LogRetentionInDays:
     Type: Number
     Default: 1
@@ -277,6 +287,9 @@ Resources:
       Environment:
         Variables:
           SEND_MESSAGE_TOPIC_ARN: !Ref SendMessageSNSTopic
+          SEND_NOTIFICATION_TOPIC_ARN: !Ref SendNotificationSNSTopic
+          MINIMUM_GROUP_SIZE_STRING: !Ref MinimumGroupSize
+          MAXIMUM_GROUP_SIZE_STRING: !Ref MaximumGroupSize
       Policies:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTableName
@@ -284,6 +297,8 @@ Resources:
           TableName: !Ref GroupsTableName
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
+      - SNSPublishMessagePolicy:
+          TopicName: !GetAtt SendNotificationSNSTopic.TopicName
       Events:
         SNSEvent:
           Type: SNS


### PR DESCRIPTION
# Create group dynamically

J'ai modifié la fonction `switchgroup` pour créer des groupes *on-the-fly*. Maintenant pas possible d'ouvrir un groupe si moins de 3 personnes, et pas plus de 5 dessus (comme expliqué dans l'*issue*).

*(bien sûr tout cela est choisi avec des variables d'environnement donc ça se bouge)*

J'ai aussi modifié très légèrement l'application pour empêcher les utilisateurs de spammer le boutons *switch group* (en relation avec la note dans le fichier `switchgroup`.

J'ai remarqué un *bug* à un moment, mais impossible de le refaire, même en tentant plusieurs fois, je le note ici au cas où on retombe dessus dans le futur.

J'ai ouvert une conversation **conv1** à 3 (donc un émulateur **A**, puis un autre émulateur **B** puis un téléphone **C**).

Puis j'ai quitté la conversation , un par un.

Donc je quitte **conv1** avec **A**, j'arrive donc sur **conv2** (le *backend* crée une nouvelle conversation) mais je ne reçois pas la notification (ça en changé dans le *backend* mais **A** n'est pas alerté car il est seul pour l'instant)

Ensuite, je quitte **conv1** avec **B**, j'arrive donc aussi sur **conv2** (seul conversation *en attente*), personne n'est alerté car moins de **3** utilisateurs.

Enfin, je quitte **conv1** avec **C**, qui devrait arriver sur **conv2** aussi, cependant **C** arrive sur **conv3** (une nouvelle conversation) et **A** et **B** sont notifié de l'ouverture de groupe **conv2** pendant que **C** reste en attente sur **conv3** 😅

J'ai essayer de le refaire plusieurs fois mais à chaque fois j'obtiens le comportement attendu, c'est à dire que **C** arrive sur **conv2**.