### PR TITLE
Use questions on group creation

### DIFF
--- a/awa-chat-flutter/awachat/lib/objects/notification_handler.dart
+++ b/awa-chat-flutter/awachat/lib/objects/notification_handler.dart
@@ -8,7 +8,7 @@ import 'package:http/http.dart' as http;
 
 class NotificationHandler {
   static const String _httpEndpoint =
-      "https://za1icir0ie.execute-api.eu-west-3.amazonaws.com/firebase-token";
+      "https://40ap385tp6.execute-api.eu-west-3.amazonaws.com/firebase-token";
 
   static final NotificationHandler _instance = NotificationHandler._internal();
 

--- a/awa-chat-flutter/awachat/lib/objects/web_socket_connection.dart
+++ b/awa-chat-flutter/awachat/lib/objects/web_socket_connection.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 
+import 'package:awachat/widgets/questions.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'package:awachat/objects/user.dart';
 
 class WebSocketConnection {
   static const String _websocketEndpoint =
-      "wss://mswpwe47tf.execute-api.eu-west-3.amazonaws.com/dev";
+      "wss://1yu5jxwgxh.execute-api.eu-west-3.amazonaws.com/dev";
 
   late WebSocketChannel _channel;
   Stream<dynamic> get stream => _channel.stream;
@@ -27,8 +28,12 @@ class WebSocketConnection {
 
   void switchgroup() {
     print('switchgroup');
-    _channel.sink.add(jsonEncode(
-        {"action": "switchgroup", "groupid": User().groupId, "id": User().id}));
+    _channel.sink.add(jsonEncode({
+      "action": "switchgroup",
+      "groupid": User().groupId,
+      "id": User().id,
+      "questions": loadSelectedAnswers()
+    }));
   }
 
   void textmessage(String encodedMessage) {

--- a/awa-chat-flutter/awachat/lib/widgets/questions.dart
+++ b/awa-chat-flutter/awachat/lib/widgets/questions.dart
@@ -70,6 +70,21 @@ Tu pourras changer tes réponses en cliquant sur ton avatar.""",
 
 // ===== ===== =====
 // Questions Loader
+
+Map<String, String> loadSelectedAnswers() {
+  final Map<String, String> selectedAnswers = {};
+  final String? encodedSelectedAnswers = Memory().get('user', 'questions');
+  if (encodedSelectedAnswers != null) {
+    encodedSelectedAnswers.split('::').forEach((element) {
+      List<String> mapEntry = element.split(':');
+      if (mapEntry.length == 2) {
+        selectedAnswers[mapEntry[0]] = mapEntry[1];
+      }
+    });
+  }
+  return selectedAnswers;
+}
+
 class QuestionsLoader extends StatefulWidget {
   const QuestionsLoader({Key? key}) : super(key: key);
 
@@ -129,22 +144,10 @@ class _QuestionsState extends State<Questions> {
         }).join("::"));
   }
 
-  void loadSelectedAnswers() {
-    final String? encodedSelectedAnswers = Memory().get('user', 'questions');
-    if (encodedSelectedAnswers != null) {
-      encodedSelectedAnswers.split('::').forEach((element) {
-        List<String> mapEntry = element.split(':');
-        if (mapEntry.length == 2) {
-          selectedAnswers[mapEntry[0]] = mapEntry[1];
-        }
-      });
-    }
-  }
-
   @override
   void initState() {
     super.initState();
-    loadSelectedAnswers();
+    selectedAnswers = loadSelectedAnswers();
     final YamlMap yaml = loadYaml(widget.data);
     if (yaml['questions'] is YamlList) {
       int index = 0;

--- a/sam-groups/actions/switchgroup/app.js
+++ b/sam-groups/actions/switchgroup/app.js
@@ -10,6 +10,8 @@
 // event.body
 // id : String - user id
 // groupid : String - group id
+// questions : Map<String, String>?
+//    question id <String> - answer id <String>
 
 // ===== ==== ====
 // IMPORTS
@@ -39,6 +41,8 @@ exports.handler = async (event) => {
 
   const id = body.id
   const groupid = body.groupid
+  const questions = body.questions
+
   if (id === undefined || groupid === undefined) {
     throw new Error('id and groupid must be defined')
   }
@@ -49,7 +53,8 @@ exports.handler = async (event) => {
     Message: JSON.stringify({
       id: id,
       groupid: groupid !== '' ? groupid : undefined,
-      connectionId: event.requestContext.connectionId
+      connectionId: event.requestContext.connectionId,
+      questions: questions
     })
   })
 

--- a/sam-groups/samconfig.toml
+++ b/sam-groups/samconfig.toml
@@ -20,7 +20,7 @@ s3_prefix = "sam-group-development"
 region = "eu-west-3"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "MinimumGroupSize=\"2\" MaximumGroupSize=\"5\" ConfirmationRequired=\"2\" GroupsTableName=\"groups_development\" LogRetentionInDays=\"1\" StageName=\"dev\""
+parameter_overrides = "MinimumGroupSize=\"2\" MaximumGroupSize=\"5\" ConfirmationRequired=\"2\" LogRetentionInDays=\"1\" StageName=\"dev\""
 image_repositories = []
 
 [prod]

--- a/sam-groups/template.yaml
+++ b/sam-groups/template.yaml
@@ -8,7 +8,7 @@ Globals:
     Environment:
       Variables:
         USERS_TABLE_NAME: !Ref UsersTable
-        GROUPS_TABLE_NAME: !Ref GroupsTableName
+        GROUPS_TABLE_NAME: !Ref GroupsTable
 
 Description: >
   sam-group
@@ -31,14 +31,6 @@ Parameters:
     Default: 2
     Description: '(Required) The number of the users required to ban someone from a group. The effective number of confirmation required will be the minimum between this number and the number of users who have received the ban request.'
     ConstraintDescription: 'Required. Must be an integer.'
-  GroupsTableName:
-    Type: String
-    Default: 'groups'
-    Description: '(Required) The name of the new DynamoDB to store registered users. Minimum 3 characters.'
-    MinLength: 3
-    MaxLength: 50
-    AllowedPattern: ^[A-Za-z_]+$
-    ConstraintDescription: 'Required. Can be characters and underscore only. No numbers or special characters allowed.'
   LogRetentionInDays:
     Type: Number
     Default: 1
@@ -83,9 +75,32 @@ Resources:
             ProjectionType: "INCLUDE"
 
   GroupsTable:
-    Type: AWS::Serverless::SimpleTable
+    Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Ref GroupsTableName
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - 
+          AttributeName: "id"
+          AttributeType: "S"
+        - 
+          AttributeName: "isWaiting"
+          AttributeType: "N"
+      KeySchema:
+        -
+          AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        -
+          IndexName: "IsWaitingIndex"
+          KeySchema:
+            -
+              AttributeName: "isWaiting"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "users"
+              - "questions"
+            ProjectionType: "INCLUDE"
 
   # Web Socket
   SimpleChatWebSocket:
@@ -327,11 +342,12 @@ Resources:
           SEND_NOTIFICATION_TOPIC_ARN: !Ref SendNotificationSNSTopic
           MINIMUM_GROUP_SIZE_STRING: !Ref MinimumGroupSize
           MAXIMUM_GROUP_SIZE_STRING: !Ref MaximumGroupSize
+          GROUPS_WAINTING_ID_INDEX_NAME: "IsWaitingIndex"
       Policies:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTable
       - DynamoDBCrudPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
       - SNSPublishMessagePolicy:
@@ -381,7 +397,7 @@ Resources:
           Type: SNS
           Properties:
             Topic: !Ref StoreUnreadDataSNSTopic
-  SwitchGroupLogGroup:
+  StoreUnreadDataLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub '/aws/lambda/${StoreUnreadDataFunction}'
@@ -426,7 +442,7 @@ Resources:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTable
       - DynamoDBReadPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
   ActionRegisterPermission:
@@ -458,7 +474,7 @@ Resources:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTable
       - DynamoDBReadPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
   ActionOnDisconnectPermission:
@@ -516,7 +532,7 @@ Resources:
       - DynamoDBReadPolicy:
           TableName: !Ref UsersTable
       - DynamoDBReadPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
       - SNSPublishMessagePolicy:
@@ -551,7 +567,7 @@ Resources:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTable
       - DynamoDBReadPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
       - SNSPublishMessagePolicy:
@@ -586,7 +602,7 @@ Resources:
       - DynamoDBCrudPolicy:
           TableName: !Ref UsersTable
       - DynamoDBReadPolicy:
-          TableName: !Ref GroupsTableName
+          TableName: !Ref GroupsTable
       - SNSPublishMessagePolicy:
           TopicName: !GetAtt SendMessageSNSTopic.TopicName
       - SNSPublishMessagePolicy:


### PR DESCRIPTION
# Use questions on group creation

**⚠️⚠️⚠️  CETTE PR VIENT APRÈS #109**

Les réponses aux questions sont maintenant envoyés au *back-end*.

Lorsqu'un utilisateur choisit un nouveau groupe, le *back-end* choisi alors le groupe qui a le plus de questions en commun avec l'utilisateur.

### Note
- Cela ne fonctionne pas lors d'un *ban* (comme les questions ne sont sauvegardé que en local, *donc après un ban t'es mis dans un groupe au total hasard*)
- Le calcul est bête est méchant, et surtout il n'est pas prouvé. Il faut qu'on puisse justifier (*statistiquement*) que les groupes vont bien se créer par *sous-ensemble* de questions (*même si ça paraît logique, je ne pense pas que ce soit évident*)