### PR TITLE
mitigate server error on register

### DIFF
--- a/chat-backend/actions/register/app.js
+++ b/chat-backend/actions/register/app.js
@@ -155,7 +155,7 @@ exports.handler = async (event) => {
     } else if (e.message === `group <${oldUser.group}> isn't found`) {
       console.log('Catch: ', e)
     } else {
-      throw e
+      console.log('Unknown error: ', e)
     }
   }
   console.log('Send Message:\n', JSON.stringify(message))

--- a/chat-backend/actions/register/helpers.js
+++ b/chat-backend/actions/register/helpers.js
@@ -60,7 +60,7 @@ exports.getOtherGroupUsers = async (userId, groupId) => {
 
 exports.informGroup = (userId, otherUsers) => {
   if (otherUsers.length === 0) {
-    return
+    return Promise.resolve()
   }
 
   const publishSendMessageCommand = new PublishCommand({

--- a/chat-backend/actions/register/helpers.js
+++ b/chat-backend/actions/register/helpers.js
@@ -35,6 +35,12 @@ exports.getOtherGroupUsers = async (userId, groupId) => {
     throw new Error(`group <${groupId}> isn't found`)
   }
 
+  const keys = Array.from(group.users).filter((id) => (id !== userId)).map((id) => ({ id }))
+
+  if (keys.length === 0) {
+    return []
+  }
+
   // retreive users
   const batchGetUsersCommand = new BatchGetCommand({
     RequestItems: {
@@ -53,6 +59,10 @@ exports.getOtherGroupUsers = async (userId, groupId) => {
 }
 
 exports.informGroup = (userId, otherUsers) => {
+  if (otherUsers.length === 0) {
+    return
+  }
+
   const publishSendMessageCommand = new PublishCommand({
     TopicArn: SEND_MESSAGE_TOPIC_ARN,
     Message: JSON.stringify({


### PR DESCRIPTION
# mitigate server error on register

Correction rapide d'un problème lié à #191.

Cette correction ne répare pas le bug mais évite des erreurs. Les utilisateurs sont toujours assigné à des groupes inactifs. Pour le moment, j'évite simplement de `BatchGet` une liste d'utilisateur vide, ce qui cause une erreur.