### PR TITLE
fix: send key from delete message as string instead of int to not crash app

### DIFF
--- a/chat-application/lib/widgets/chat/main.dart
+++ b/chat-application/lib/widgets/chat/main.dart
@@ -186,7 +186,7 @@ class _ChatHandlerState extends State<ChatHandler> with WidgetsBindingObserver {
             types.TextMessage.fromJson(message.toJson()));
         break;
       case 'delete':
-        Memory().boxMessages.delete(message.createdAt);
+        Memory().boxMessages.delete(message.createdAt.toString());
         break;
       case 'block':
         blockUser(message.author.id);


### PR DESCRIPTION
# fix: send key from delete message as string instead of int to not crash app

Raison du crash:
1. Pour trier les messages par clef, la mémoire _parse_ les _string_ en _int_
2. La méthode _deleteMessage_ supprimait une clef _int_
3. Impossible de _parse_ un _int_, il y a erreur de _type_

**Note:** on utilise des _string_ et non des _int_ même si on fait des conversation (_parse_) car la limite de _int_ est **4294967295** (0xFFFFFFFF), qui est plus grand que le plus petit _timestamps_ qu'on croise.
On pourrait utiliser une comparaison alphabétique (sûrement plus rapide d'ailleurs), à voir si ça vaut le coup (quelque _problème/edge case_ à régler, par exemple `2 > 11`..)
