### PR TITLE
366 save message being type when closing app

### DIFF
--- a/chat-application/android/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/chat-application/android/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,1 +1,1 @@
-- Mise à jour des visuels de présentation
+- Amélioration de la zone de saisie de texte

--- a/chat-application/ios/fastlane/metadata/fr-FR/release_notes.txt
+++ b/chat-application/ios/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,1 +1,1 @@
-- Mise à jour des visuels de présentation
+- Amélioration de la zone de saisie de texte

--- a/chat-application/lib/widgets/chat/widgets/flyer_chat.dart
+++ b/chat-application/lib/widgets/chat/widgets/flyer_chat.dart
@@ -30,6 +30,7 @@ class FlyerChat extends StatelessWidget {
         onSendPressed: onSendPressed,
         onMessageLongPress: onMessageLongPress,
         user: types.User(id: User().id!),
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         theme: DefaultChatTheme(
             primaryColor: Theme.of(context).colorScheme.onPrimary,
             inputBackgroundColor: Theme.of(context).colorScheme.primary,

--- a/chat-application/lib/widgets/chat/widgets/flyer_chat.dart
+++ b/chat-application/lib/widgets/chat/widgets/flyer_chat.dart
@@ -1,4 +1,5 @@
 import 'package:awachat/l10n/flyer_l10n.dart';
+import 'package:awachat/store/memory.dart';
 import 'package:awachat/store/user.dart';
 import 'package:awachat/widgets/chat/widgets/flyer_user_avatar.dart';
 import 'package:flutter/material.dart';
@@ -6,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 
-class FlyerChat extends StatelessWidget {
+class FlyerChat extends StatefulWidget {
   const FlyerChat(
       {Key? key,
       required this.messages,
@@ -19,6 +20,19 @@ class FlyerChat extends StatelessWidget {
   final void Function(BuildContext, types.Message)? onMessageLongPress;
 
   @override
+  State<FlyerChat> createState() => _FlyerChatState();
+}
+
+class _FlyerChatState extends State<FlyerChat> {
+  final InputTextFieldController _controller = InputTextFieldController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = Memory().boxUser.get('typingMessage') ?? '';
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Chat(
         avatarBuilder: (String userId) => FlyerUserAvatar(userId: userId),
@@ -26,11 +40,19 @@ class FlyerChat extends StatelessWidget {
         showUserAvatars: true,
         textMessageOptions: const TextMessageOptions(isTextSelectable: false),
         l10n: const ChatL10nFr(),
-        messages: messages,
-        onSendPressed: onSendPressed,
-        onMessageLongPress: onMessageLongPress,
+        messages: widget.messages,
+        onSendPressed: (types.PartialText text) {
+          widget.onSendPressed(text);
+          Memory().boxUser.delete('typingMessage');
+        },
+        onMessageLongPress: widget.onMessageLongPress,
         user: types.User(id: User().id!),
         keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        inputOptions: InputOptions(
+            textEditingController: _controller,
+            onTextChanged: (String text) {
+              Memory().boxUser.put('typingMessage', text);
+            }),
         theme: DefaultChatTheme(
             primaryColor: Theme.of(context).colorScheme.onPrimary,
             inputBackgroundColor: Theme.of(context).colorScheme.primary,

--- a/chat-application/pubspec.yaml
+++ b/chat-application/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.5
+version: 1.0.6
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
# 366 save message being type when closing app

Lorsque tu types, le message n'est pas perdu quand tu quittes l'application, la logique est confiné au niveau du `FlyerChat` pour ne pas avoir à gérer les memory keys ailleurs.

Potentiel drawback: Si il y a une erreur pendant l'envoie ou que l'utilisateur ferme l'application avant que l'envoie ne soit fait, le chant ne sera pas supprimé de la mémoire, donc toujours présent la prochaine fois qu'il ouvre l'application (est-ce vraiment un problème dans la mesure ou du coup le message ne sera pas envoyé?)

On peut conserver tel quel pour le moment, si il y a des bugs on changera